### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+**Product:** CloneRefactor — a Java CLI tool that detects code clones (Type 1/2/3) in Java projects using AST-based analysis (JavaParser) and can automatically refactor a subset of detected clones.
+
+**Build system:** Maven 3.x with JDK 21 (project targets Java 8 source level, compatible with JDK 21).
+
+### Build / Test / Run commands
+
+| Action | Command |
+|--------|---------|
+| Compile | `mvn clean compile` |
+| Test | `mvn test` |
+| Package (JAR) | `mvn clean package -DskipTests` |
+| Run CLI | `java -cp "target/clonerefactor-1.0.jar:$(mvn -q dependency:build-classpath -Dmdep.outputFile=/dev/stdout)" com.simonbaars.clonerefactor.Main <path-to-java-project>` |
+
+### Non-obvious notes
+
+- **Pre-existing test failures:** The test suite (72 tests) has pre-existing failures (3 failures, 54 errors) on `master`. The `Type1Test`, `Type2Test`, `Type3Test` helper classes fail because they contain no JUnit 3 test methods. The `CloneRelationTest` errors are `NoSuchElementException` bugs in test code (not environment-related).
+- **`mvn exec:java` uses `RunOnCorpus`:** The `pom.xml` configures `exec-maven-plugin` to run `RunOnCorpus` (batch corpus analysis), not `Main`. To run the CLI entry point, invoke `Main` directly via `java -cp` as shown above.
+- **Output directory:** The tool writes results to `~/clone/output/<timestamp>/`. Ensure `~/clone/output/` exists or let the tool create it.
+- **JVM config:** `.mvn/jvm.config` sets `-Xms2G -Xmx10G -Xss20m`. This applies to Maven-invoked tasks but not to direct `java -cp` invocations (add these flags manually if needed for large projects).
+- **No lint tool configured:** There is no dedicated linter; `mvn compile` serves as the primary static check.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for the CloneRefactor project.

### What's included

- Build/test/run command reference table
- Non-obvious notes about pre-existing test failures, `exec:java` configuration, output directories, JVM config, and lack of a dedicated linter
- Instructions for running the CLI entry point directly (since `mvn exec:java` targets `RunOnCorpus`, not `Main`)

### Environment verification

The development environment was verified end-to-end:

| Check | Result |
|-------|--------|
| `mvn clean compile` | 153 source files compiled successfully |
| `mvn test` | 72 tests run (pre-existing: 3 failures, 54 errors — not environment-related) |
| `mvn clean package -DskipTests` | JAR built successfully |
| Clone detection on own source | Detected 15 clone classes, 530 cloned lines across 153 source files |

### Clone detection output (hello-world demo)

[clone_detection_output.log](https://cursor.com/agents/bc-db7baf28-7b8a-4de2-aec8-3bf13f093c35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclone_detection_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db7baf28-7b8a-4de2-aec8-3bf13f093c35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db7baf28-7b8a-4de2-aec8-3bf13f093c35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

